### PR TITLE
fix docker build invalidating 'go get' cache layer

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -12,9 +12,14 @@ RUN apk update && \
 		git && \
 	rm -rf /var/lib/apt/lists/*
 
-COPY . $APP_HOME
 WORKDIR $APP_HOME
+
+COPY go.mod .
+COPY go.sum .
+
 RUN GO111MODULE=on go get -v -d ./...
+
+COPY . .
 
 WORKDIR $APP_HOME/cmd/instagramsaverbot
 RUN env CGO_ENABLE=1 GOOS=linux GOARCH=386 go build -o /go/bin/instagramsaverbot

--- a/go.mod
+++ b/go.mod
@@ -18,3 +18,5 @@ require (
 	gopkg.in/yaml.v2 v2.2.2
 	mvdan.cc/xurls/v2 v2.0.0
 )
+
+go 1.13

--- a/go.mod
+++ b/go.mod
@@ -19,4 +19,4 @@ require (
 	mvdan.cc/xurls/v2 v2.0.0
 )
 
-go 1.13
+go 1.11


### PR DESCRIPTION
This PR reduces the Docker image build times when there are file changes to any files.

- any file changes invalidate all subsequent layers when copying root
- only copy go.mod and go.sum before 'go get'

References:
- [Best practices for writing Dockerfiles](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/)
- [Using go mod download to speed up Golang Docker builds](https://medium.com/@petomalina/using-go-mod-download-to-speed-up-golang-docker-builds-707591336888)